### PR TITLE
Move vagrant playbook into this role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,66 @@
-WIP
+OULibraries.repox
+=========
 
-This will be an [Ansible](https://www.ansible.com/ "main Ansible site") [role](http://docs.ansible.com/ansible/playbooks_roles.html "playbook roles documentation") that adds [REPOX](https://github.com/europeana/REPOX "REPOX on github") to a machine.
+[REPOX](https://github.com/europeana/REPOX "REPOX on github") for OU Libraries.
 
-Right now, it's only [the default variables for the role](http://docs.ansible.com/ansible/playbooks_roles.html#role-default-variables "Ansible documentation on default variables").
+gotchas:
+ some ansible variables don't actually support changing at this time
+  I'm not sure what db.privileges needs to be
+  repox_path_source needs to be a nonexistent immediate subdirectory of an existing directory
+  repox_path_data needs to be a nonexistent immediate subdirectory of an existing directory
+  repox_path_log needs to be an existing directory
+  no path should end with a /
+  repox_source_tag must be v3.1.0 or the j2 templates need to change accordingly
+  ldap is wrong
+  repox_base_urn is wrong
+  smtp is wrong
 
-There is a [playbook](http://docs.ansible.com/ansible/playbooks_intro.html "Ansible playbook documentation") in another repository, and that playbook will use this role.  Eventually, that playbook will have its guts siphoned into this role.
+TODO:
+  finish e-mail configuration and testing
+  test with SELinux
+  remove default password from role
+  remove remaining vagrant-specific bits.
+
+
+Requirements
+------------
+
+CentOS 7x.
+
+Role Variables
+--------------
+
+See defaults/main.yml
+
+Dependencies
+------------
+
+OULibraries.centos7
+OULibraries.repox
+OULibraries.postfix-mta
+OULibraries.users
+
+Example Playbook
+----------------
+
+
+```
+- hosts: servers
+  sudo: yes
+  vars_files:
+    - my-vars.yml
+  roles:
+    - OULibraries.centos7
+    - OULibraries.repox
+    - OULibraries.users
+```
+
+License
+-------
+
+TBD
+
+Author Information
+------------------
+
+Montana Rowe

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@
 # they are namespaced
 
 # mariadb configuration
+repox_mariadb_host: localhost
+repox_mariadb_port: 3306
 repox_mariadb_username: repox
 repox_mariadb_password: repox
 repox_mariadb_database: repoxdb
@@ -12,6 +14,7 @@ repox_mariadb_privileges: ALL
 repox_path_source: /home/vagrant/repox
 repox_path_data: /data
 repox_path_log: /var/log
+repox_path_tomcat: /usr/share/tomcat
 
 # the user that logs in to the web interface
 repox_admin_username: admin

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for repox

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,6 @@ galaxy_info:
   author: Montana Rowe
   company: OU Libraries
   description: REPOX webserver
-  min_ansible_version: 1.9
+  min_ansible_version: 2.1
   license: ALL RIGHTS RESERVED
 dependencies: []

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,0 +1,6 @@
+---
+- name: compile repox with maven
+  command: "mvn -B -l {{ path.log }}/maven.log -q clean install -Pproduction"
+  args:
+    chdir: "{{ path.source }}/"
+    creates: "{{ path.source }}/gui/target/repox.war"

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,6 +1,6 @@
 ---
 - name: compile repox with maven
-  command: "mvn -B -l {{ repox_path_log }}/maven.log -q clean install -Pproduction"
+  command: "mvn -B -e -l {{ repox_path_log }}/maven.log -q clean install -Pproduction"
   args:
     chdir: "{{ repox_path_source }}/"
     creates: "{{ repox_path_source }}/gui/target/repox.war"

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,6 +1,6 @@
 ---
 - name: compile repox with maven
-  command: "mvn -B -l {{ path.log }}/maven.log -q clean install -Pproduction"
+  command: "mvn -B -l {{ repox_path_log }}/maven.log -q clean install -Pproduction"
   args:
-    chdir: "{{ path.source }}/"
-    creates: "{{ path.source }}/gui/target/repox.war"
+    chdir: "{{ repox_path_source }}/"
+    creates: "{{ repox_path_source }}/gui/target/repox.war"

--- a/tasks/database.yml
+++ b/tasks/database.yml
@@ -1,0 +1,12 @@
+---
+- name: repox database
+  mysql_db:
+    name: "{{ db.database }}"
+    state: present
+- name: repox user for database
+  mysql_user:
+    name: "{{ db.username }}"
+    host: "{{ db.host }}"
+    password: "{{ db.password }}"
+    priv: "{{ db.database }}.*:{{ db.privileges }}"
+    state: present

--- a/tasks/database.yml
+++ b/tasks/database.yml
@@ -1,12 +1,12 @@
 ---
 - name: repox database
   mysql_db:
-    name: "{{ db.database }}"
+    name: "{{ repox_mariadb_database }}"
     state: present
 - name: repox user for database
   mysql_user:
-    name: "{{ db.username }}"
-    host: "{{ db.host }}"
-    password: "{{ db.password }}"
-    priv: "{{ db.database }}.*:{{ db.privileges }}"
+    name: "{{ repox_mariadb_username }}"
+    host: "{{ repox_mariadb_host }}"
+    password: "{{ repox_mariadb_password }}"
+    priv: "{{ repox_mariadb_database }}.*:{{ repox_mariadb_privileges }}"
     state: present

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,9 +1,9 @@
 ---
 - name: install the repox war into tomcat
   copy:
-    src: "{{ path.source }}/gui/target/repox.war"
-    dest: "{{ path.tomcat }}/webapps/"
+    src: "{{ repox_path_source }}/gui/target/repox.war"
+    dest: "{{ repox_path_tomcat }}/webapps/"
 - name: replace default admin user
   template:
-    src: "{{ path.playbook }}/users.xml.j2"
-    dest: "{{ path.data }}/repoxData/configuration/users.xml"
+    src: "{{ repox_path_playbook }}/users.xml.j2"
+    dest: "{{ repox_path_data }}/repoxData/configuration/users.xml"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,0 +1,9 @@
+---
+- name: install the repox war into tomcat
+  copy:
+    src: "{{ path.source }}/gui/target/repox.war"
+    dest: "{{ path.tomcat }}/webapps/"
+- name: replace default admin user
+  template:
+    src: "{{ path.playbook }}/users.xml.j2"
+    dest: "{{ path.data }}/repoxData/configuration/users.xml"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -5,5 +5,5 @@
     dest: "{{ repox_path_tomcat }}/webapps/"
 - name: replace default admin user
   template:
-    src: "{{ repox_path_playbook }}/users.xml.j2"
+    src: users.xml.j2
     dest: "{{ repox_path_data }}/repoxData/configuration/users.xml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,13 @@
 ---
 - include: yum.yml
+  sudo: yes
 - include: services.yml
+  sudo: yes
 - include: database.yml
+  sudo: yes
 - include: source.yml
+  sudo: yes
 - include: build.yml
+  sudo: yes
 - include: deploy.yml
-  vars:
-    admin: "{{ repox_admin }}"
-# TODO: set up e-mail
+  sudo: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- include: yum.yml
+- include: services.yml
+- include: database.yml
+- include: source.yml
+- include: build.yml
+- include: deploy.yml
+  vars:
+    admin: "{{ repox_admin }}"
+# TODO: set up e-mail

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,0 +1,8 @@
+---
+- name: database and tomcat services
+  service:
+    name: "{{ item }}"
+    state: started
+  with_items:
+  - mariadb
+  - tomcat

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -1,0 +1,24 @@
+---
+- name: repox source code
+  git:
+    repo: https://github.com/europeana/REPOX.git
+    dest: "{{ path.source }}/"
+    version: "{{ source_tag }}"
+- name: replace default repox configuration
+  template:
+    src: "{{ path.playbook }}/configuration.properties.j2"
+    dest: "{{ path.source }}/resources/src/main/resources/configuration.properties"
+- name: data directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: tomcat
+  with_items:
+  - "{{ path.data }}"
+  - "{{ path.data }}/repoxData"
+  - "{{ path.data }}/repoxData/repository"
+  - "{{ path.data }}/repoxData/configuration"
+  - "{{ path.data }}/repoxData/[temp]OAI-PMH_Requests"
+  - "{{ path.data }}/repoxData/[temp]FTP_Requests"
+  - "{{ path.data }}/repoxData/[temp]HTTP_Requests"
+  - "{{ path.data }}/repoxData/export"

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -2,23 +2,23 @@
 - name: repox source code
   git:
     repo: https://github.com/europeana/REPOX.git
-    dest: "{{ path.source }}/"
+    dest: "{{ repox_path_source }}/"
     version: "{{ source_tag }}"
 - name: replace default repox configuration
   template:
-    src: "{{ path.playbook }}/configuration.properties.j2"
-    dest: "{{ path.source }}/resources/src/main/resources/configuration.properties"
+    src: "{{ repox_path_playbook }}/configuration.properties.j2"
+    dest: "{{ repox_path_source }}/resources/src/main/resources/configuration.properties"
 - name: data directories
   file:
     path: "{{ item }}"
     state: directory
     owner: tomcat
   with_items:
-  - "{{ path.data }}"
-  - "{{ path.data }}/repoxData"
-  - "{{ path.data }}/repoxData/repository"
-  - "{{ path.data }}/repoxData/configuration"
-  - "{{ path.data }}/repoxData/[temp]OAI-PMH_Requests"
-  - "{{ path.data }}/repoxData/[temp]FTP_Requests"
-  - "{{ path.data }}/repoxData/[temp]HTTP_Requests"
-  - "{{ path.data }}/repoxData/export"
+  - "{{ repox_path_data }}"
+  - "{{ repox_path_data }}/repoxData"
+  - "{{ repox_path_data }}/repoxData/repository"
+  - "{{ repox_path_data }}/repoxData/configuration"
+  - "{{ repox_path_data }}/repoxData/[temp]OAI-PMH_Requests"
+  - "{{ repox_path_data }}/repoxData/[temp]FTP_Requests"
+  - "{{ repox_path_data }}/repoxData/[temp]HTTP_Requests"
+  - "{{ repox_path_data }}/repoxData/export"

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -6,7 +6,7 @@
     version: "{{ repox_source_tag }}"
 - name: replace default repox configuration
   template:
-    src: "{{ repox_path_playbook }}/configuration.properties.j2"
+    src: /configuration.properties.j2
     dest: "{{ repox_path_source }}/resources/src/main/resources/configuration.properties"
 - name: data directories
   file:

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -6,7 +6,7 @@
     version: "{{ repox_source_tag }}"
 - name: replace default repox configuration
   template:
-    src: /configuration.properties.j2
+    src: configuration.properties.j2
     dest: "{{ repox_path_source }}/resources/src/main/resources/configuration.properties"
 - name: data directories
   file:

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -3,7 +3,7 @@
   git:
     repo: https://github.com/europeana/REPOX.git
     dest: "{{ repox_path_source }}/"
-    version: "{{ source_tag }}"
+    version: "{{ repox_source_tag }}"
 - name: replace default repox configuration
   template:
     src: "{{ repox_path_playbook }}/configuration.properties.j2"

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -1,0 +1,13 @@
+---
+- name: packages for the repox installation
+  yum:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+  - java
+  - tomcat
+  - mariadb-server
+  - git
+  - maven
+  - patch
+  - MySQL-python

--- a/templates/configuration.properties.j2
+++ b/templates/configuration.properties.j2
@@ -26,7 +26,7 @@ exportDefaultFolder = {{ path.data }}/repoxData/export
 sample.records = 1000
 
 # URN prefix of this REPOX instance (syntax is urn:[instance identifier]:)
-baseurn = {{ base_urn }}
+baseurn = {{ repox_base_urn }}
 
 #LDAP Configuration, commas must be escaped
 ldapHost = ldaps://{{ repox_ldap_host }}

--- a/templates/configuration.properties.j2
+++ b/templates/configuration.properties.j2
@@ -1,0 +1,69 @@
+# Directory of the REPOX Repository (XML files)
+repository.dir = {{ path.data }}/repoxData/repository
+#repository.dir = /data/repox/repository
+
+# Directory of the REPOX XML Dynamic Configuration Files (DataProviders, Statistics)
+xmlConfig.dir = {{ path.data }}/repoxData/configuration
+#xmlConfig.dir = /data/repox/configuration
+
+# Directory for the temporary OAI-PMH requests
+oairequests.dir = {{ path.data }}/repoxData/[temp]OAI-PMH_Requests
+#oairequests.dir = /data/repox/[temp]OAI-PMH_Requests
+
+# Directory for the temporary FTP requests
+ftprequests.dir = {{ path.data }}/repoxData/[temp]FTP_Requests
+#ftprequests.dir = /data/repox/[temp]FTP_Requests
+
+# Directory for the temporary HTTP requests
+httprequests.dir = {{ path.data }}/repoxData/[temp]HTTP_Requests
+#httprequests.dir = /data/repox/[temp]HTTP_Requests
+
+# Export folder
+exportDefaultFolder = {{ path.data }}/repoxData/export
+#exportDefaultFolder = /data/repox/export
+
+# Sample Record's number
+sample.records = 1000
+
+# URN prefix of this REPOX instance (syntax is urn:[instance identifier]:)
+baseurn = {{ base_urn }}
+
+#LDAP Configuration, commas must be escaped
+ldapHost = ldaps://{{ repox_ldap_host }}
+ldapRootDN = uid=tel-ldap\,ou=users\,ou=system
+ldapRootPassword = {{ repox_ldap_password }}
+ldapBasePath = ou=office\,ou=users\,ou=tel\,dc=theeuropeanlibrary\,dc=org
+
+##########################################################################
+##################### ADVANCED PROPERTIES ################################
+##########################################################################
+# Administrator Email(Used for retrieving log information)
+administrator.email = {{ email.admin }}
+#Default Repox Sender eamil, used for sending emails
+default.email = {{ email.address }}
+default.email.pass = {{ email.password }}
+smtp.server = {{ email.host }}
+smtp.port = {{ email.port }}
+
+#Database: PostgreSQL
+#database.driverClassName = org.postgresql.Driver
+#database.url = jdbc:postgresql://localhost/repox
+#database.user = repox
+#database.password = repox
+
+#Database: PostgreSQL
+#database.driverClassName = org.postgresql.Driver
+#database.url = jdbc:postgresql://localhost/repox
+#database.user = repox
+#database.password = repox
+
+#Database: MySQL
+database.driverClassName = com.mysql.jdbc.Driver
+database.url = jdbc:mysql://{{ repox_mariadb_host }}:{{ repox_mariadb_port }}/{{ repox_mariadb_database }}
+database.user = {{ repox_mariadb_username }}
+database.password = {{ repox_mariadb_password }}
+
+userCountriesTxtFile = true
+sendEmailAfterIngest = false
+useMailSSLAuthentication = true
+useOAINamespace = false

--- a/templates/configuration.properties.j2
+++ b/templates/configuration.properties.j2
@@ -1,25 +1,25 @@
 # Directory of the REPOX Repository (XML files)
-repository.dir = {{ path.data }}/repoxData/repository
+repository.dir = {{ repox_path_data }}/repoxData/repository
 #repository.dir = /data/repox/repository
 
 # Directory of the REPOX XML Dynamic Configuration Files (DataProviders, Statistics)
-xmlConfig.dir = {{ path.data }}/repoxData/configuration
+xmlConfig.dir = {{ repox_path_data }}/repoxData/configuration
 #xmlConfig.dir = /data/repox/configuration
 
 # Directory for the temporary OAI-PMH requests
-oairequests.dir = {{ path.data }}/repoxData/[temp]OAI-PMH_Requests
+oairequests.dir = {{ repox_path_data }}/repoxData/[temp]OAI-PMH_Requests
 #oairequests.dir = /data/repox/[temp]OAI-PMH_Requests
 
 # Directory for the temporary FTP requests
-ftprequests.dir = {{ path.data }}/repoxData/[temp]FTP_Requests
+ftprequests.dir = {{ repox_path_data }}/repoxData/[temp]FTP_Requests
 #ftprequests.dir = /data/repox/[temp]FTP_Requests
 
 # Directory for the temporary HTTP requests
-httprequests.dir = {{ path.data }}/repoxData/[temp]HTTP_Requests
+httprequests.dir = {{ repox_path_data }}/repoxData/[temp]HTTP_Requests
 #httprequests.dir = /data/repox/[temp]HTTP_Requests
 
 # Export folder
-exportDefaultFolder = {{ path.data }}/repoxData/export
+exportDefaultFolder = {{ repox_path_data }}/repoxData/export
 #exportDefaultFolder = /data/repox/export
 
 # Sample Record's number
@@ -38,12 +38,12 @@ ldapBasePath = ou=office\,ou=users\,ou=tel\,dc=theeuropeanlibrary\,dc=org
 ##################### ADVANCED PROPERTIES ################################
 ##########################################################################
 # Administrator Email(Used for retrieving log information)
-administrator.email = {{ email.admin }}
+administrator.email = {{ repox_admin_email }}
 #Default Repox Sender eamil, used for sending emails
-default.email = {{ email.address }}
-default.email.pass = {{ email.password }}
-smtp.server = {{ email.host }}
-smtp.port = {{ email.port }}
+default.email = {{ repox_smtp_address }}
+default.email.pass = {{ repox_smtp_password }}
+smtp.server = {{ repox_smtp_host }}
+smtp.port = {{ repox_smtp_port }}
 
 #Database: PostgreSQL
 #database.driverClassName = org.postgresql.Driver

--- a/templates/users.xml.j2
+++ b/templates/users.xml.j2
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<users>
+  <user>
+    <userName>{{ repox_admin_username }}</userName>
+    <pass>{{ repox_admin_passhash }}</pass>
+    <role>ADMIN</role>
+    <email>{{ repox_admin_email }}</email>
+  </user>
+</users>

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - repox

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for repox


### PR DESCRIPTION
This moves the vagrant_repox ansible playbook tasks into this role.  It also reflects changes needed to bring the role more into line with the rest of OU Libraries ansible roles.